### PR TITLE
Add pool_name label to pool metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.2.1] - 2021-05-09
+
+### Changed
+
+- Included label `pool_name` for all pool metrics for better usability.
+
 ## [1.2.0] - 2021-05-09
 
 ### Added

--- a/cmd/prometheus-ethermine-exporter/main.go
+++ b/cmd/prometheus-ethermine-exporter/main.go
@@ -321,15 +321,14 @@ func buildPoolRegistry(response http.ResponseWriter, pool *Pool, basicData *pool
 	util.NewExporterMetric(registry, namespace, appVersion)
 
 	constLabels := prometheus.Labels{
-		"pool": pool.ID,
+		"pool":      pool.ID,
+		"pool_name": pool.Name,
 	}
 
 	// Pool info
-	util.NewGauge(registry, namespace, "pool", "info", "Metadata about the pool.", prometheus.Labels{
-		"pool":     pool.ID,
-		"name":     pool.Name,
+	util.NewGauge(registry, namespace, "pool", "info", "Metadata about the pool.", util.MergeLabels(constLabels, prometheus.Labels{
 		"currency": string(pool.Currency),
-	}).Set(1)
+	})).Set(1)
 
 	// Basic stats
 	util.NewGauge(registry, namespace, "pool", "hashrate_hps", "Current total hash rate of the pool (H/s).", constLabels).Set(basicData.Data.Stats.HashRate)
@@ -378,12 +377,10 @@ func buildMinerRegistry(response http.ResponseWriter, pool *Pool, minerAddress s
 	baseUnitsPerUnit := Currencies[pool.Currency].BaseUnitsPerUnit
 
 	// Miner info
-	util.NewGauge(registry, namespace, "miner", "info", "Metadata about the miner.", prometheus.Labels{
-		"pool":          pool.ID,
-		"miner":         minerAddress,
+	util.NewGauge(registry, namespace, "miner", "info", "Metadata about the miner.", util.MergeLabels(constLabels, prometheus.Labels{
 		"pool_name":     pool.Name,
 		"pool_currency": string(pool.Currency),
-	}).Set(1)
+	})).Set(1)
 
 	// Miner stats
 	util.NewGauge(registry, namespace, "miner", "last_seen_seconds", "Delta between time of last statistics entry and when any workers from the miner was last seen (s).", constLabels).Set(statsData.Data.Timestamp - statsData.Data.LastSeenTimestamp)

--- a/examples/output-pool.txt
+++ b/examples/output-pool.txt
@@ -3,25 +3,25 @@
 ethermine_exporter_info{version="0.0.0-SNAPSHOT"} 1
 # HELP ethermine_pool_hashrate_hps Current total hash rate of the pool (H/s).
 # TYPE ethermine_pool_hashrate_hps gauge
-ethermine_pool_hashrate_hps{pool="ethermine"} 1.1636533160266422e+14
+ethermine_pool_hashrate_hps{pool="ethermine",pool_name="Ethermine"} 1.1627791764115673e+14
 # HELP ethermine_pool_info Metadata about the pool.
 # TYPE ethermine_pool_info gauge
-ethermine_pool_info{currency="ETH",name="Ethermine",pool="ethermine"} 1
+ethermine_pool_info{currency="ETH",pool="ethermine",pool_name="Ethermine"} 1
 # HELP ethermine_pool_miner_count Current total number of miners in the pool.
 # TYPE ethermine_pool_miner_count gauge
-ethermine_pool_miner_count{pool="ethermine"} 276367
+ethermine_pool_miner_count{pool="ethermine",pool_name="Ethermine"} 276036
 # HELP ethermine_pool_price_btc Current price (BTC).
 # TYPE ethermine_pool_price_btc gauge
-ethermine_pool_price_btc{pool="ethermine"} 0.06812
+ethermine_pool_price_btc{pool="ethermine",pool_name="Ethermine"} 0.0678
 # HELP ethermine_pool_price_usd Current price (USD).
 # TYPE ethermine_pool_price_usd gauge
-ethermine_pool_price_usd{pool="ethermine"} 3911.89
+ethermine_pool_price_usd{pool="ethermine",pool_name="Ethermine"} 3894.06
 # HELP ethermine_pool_server_hashrate_hps Current hash rate per server (H/s).
 # TYPE ethermine_pool_server_hashrate_hps gauge
-ethermine_pool_server_hashrate_hps{pool="ethermine",server="asia1"} 2.2382611483885996e+13
-ethermine_pool_server_hashrate_hps{pool="ethermine",server="eu1"} 6.828889379622365e+13
-ethermine_pool_server_hashrate_hps{pool="ethermine",server="us1"} 1.7042861147355621e+13
-ethermine_pool_server_hashrate_hps{pool="ethermine",server="us2"} 8.6509651751318125e+12
+ethermine_pool_server_hashrate_hps{pool="ethermine",pool_name="Ethermine",server="asia1"} 2.2389020508017664e+13
+ethermine_pool_server_hashrate_hps{pool="ethermine",pool_name="Ethermine",server="eu1"} 6.827537971402743e+13
+ethermine_pool_server_hashrate_hps{pool="ethermine",pool_name="Ethermine",server="us1"} 1.6980130321965209e+13
+ethermine_pool_server_hashrate_hps{pool="ethermine",pool_name="Ethermine",server="us2"} 8.633387097077387e+12
 # HELP ethermine_pool_worker_count Current total number of workers in the pool.
 # TYPE ethermine_pool_worker_count gauge
-ethermine_pool_worker_count{pool="ethermine"} 732030
+ethermine_pool_worker_count{pool="ethermine",pool_name="Ethermine"} 730405


### PR DESCRIPTION
### Changed

- Included label `pool_name` for all pool metrics for better usability.